### PR TITLE
Create and run migrations for players and matches

### DIFF
--- a/db/migrate/20210209201402_create_players.rb
+++ b/db/migrate/20210209201402_create_players.rb
@@ -1,0 +1,11 @@
+class CreatePlayers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :players do |t|
+      t.string :name
+      t.string :ranking
+      t.string :location
+      t.string :username
+      t.string :password
+    end
+  end
+end

--- a/db/migrate/20210209202318_create_matches.rb
+++ b/db/migrate/20210209202318_create_matches.rb
@@ -1,0 +1,12 @@
+class CreateMatches < ActiveRecord::Migration[5.2]
+  def change
+    create_table :matches do |t|
+      t.string :type
+      t.string :score
+      t.string :result
+      t.string :date
+      t.string :surface
+      t.string :notes
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,35 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2021_02_09_202318) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "matches", force: :cascade do |t|
+    t.string "type"
+    t.string "score"
+    t.string "result"
+    t.string "date"
+    t.string "surface"
+    t.string "notes"
+  end
+
+  create_table "players", force: :cascade do |t|
+    t.string "name"
+    t.string "ranking"
+    t.string "location"
+    t.string "username"
+    t.string "password"
+  end
+
+end


### PR DESCRIPTION
Create and run new migrations for Players and Matches.

Followed attributes from Miro board.

DID NOT add foreign key for players and matches. A little confused how we might do that needing multiple players for one match. Let me know your thoughts.